### PR TITLE
SHEN-19483 Add REST Catalog stack trace to exception message

### DIFF
--- a/pyiceberg/catalog/rest/response.py
+++ b/pyiceberg/catalog/rest/response.py
@@ -46,6 +46,7 @@ class ErrorResponseMessage(IcebergBaseModel):
     message: str = Field()
     type: str = Field()
     code: int = Field()
+    stack: Optional[list[str]] = Field(default=None)
 
 
 class ErrorResponse(IcebergBaseModel):
@@ -100,6 +101,9 @@ def _handle_non_200_response(exc: HTTPError, error_handler: Dict[int, Type[Excep
         else:
             error = ErrorResponse.model_validate_json(exc.response.text).error
             response = f"{error.type}: {error.message}"
+
+            if exception in (ServerError,):
+                response += f". Stack trace: \n{''.join(error.stack or [])}"
     except JSONDecodeError:
         # In the case we don't have a proper response
         response = f"RESTError {exc.response.status_code}: Could not decode json payload: {exc.response.text}"

--- a/tests/catalog/test_rest.py
+++ b/tests/catalog/test_rest.py
@@ -819,6 +819,34 @@ def test_namespace_exists_500(rest_mock: Mocker) -> None:
         catalog.namespace_exists("fokko")
 
 
+def test_namespace_exists_500_includes_stack_trace(rest_mock: Mocker) -> None:
+    rest_mock.head(
+        f"{TEST_URI}v1/namespaces/fokko",
+        json={
+            "error": {
+                "message": "Unknown failure",
+                "type": "UncheckedSQLException",
+                "code": 500,
+                "stack": [
+                    "UncheckedSQLException: Unknown failure\n",
+                    "\tat com.example.DB.query(DB.java:42)\n",
+                    "\tat com.example.Catalog.namespaceExists(Catalog.java:10)\n",
+                ],
+            }
+        },
+        status_code=500,
+        request_headers=TEST_HEADERS,
+    )
+    catalog = RestCatalog("rest", uri=TEST_URI, token=TEST_TOKEN)
+
+    with pytest.raises(ServerError) as exc_info:
+        catalog.namespace_exists("fokko")
+
+    assert "UncheckedSQLException: Unknown failure" in str(exc_info.value)
+    assert "Stack trace:" in str(exc_info.value)
+    assert "com.example.DB.query" in str(exc_info.value)
+
+
 def test_update_namespace_properties_404(rest_mock: Mocker) -> None:
     rest_mock.post(
         f"{TEST_URI}v1/namespaces/fokko/properties",


### PR DESCRIPTION
When the Iceberg REST catalog server returns a 500 error, we currently only include the error type and message in the resulting Python exception raised. For example, for an UncheckedSQLException with message "Unknown failure", we raise a
`ServerError('UncheckedSQLException: Unknown failure')`.

This is not very informative as often the root cause of these exceptions is hidden in the server side stack trace. We already send the stack trace as part of the error response, but we do not include it in the Python exception message.

Let's include the stack trace in the exception message for 500 errors (ServerError).
