### PR TITLE
fix: Use permissive promote in merge() concat for large_string drift

### DIFF
--- a/pyiceberg/table/__init__.py
+++ b/pyiceberg/table/__init__.py
@@ -996,7 +996,17 @@ class Transaction:
 
         kept_rows = target_data.join(source_keys, keys=join_cols, join_type="left anti")
         rows_deleted = target_data.num_rows - kept_rows.num_rows
-        new_content = pa.concat_tables([kept_rows, df], promote_options="default")
+        # ``ArrowScan.to_table()`` can return text/binary columns as the
+        # ``large_*`` PyArrow variants (utf8 vs large_utf8, binary vs
+        # large_binary) while the user-provided ``df`` from pandas->arrow
+        # typically produces the non-large variants. Both sides are
+        # semantically the same Iceberg type; the difference is purely
+        # PyArrow physical encoding. ``promote_options="default"`` refuses
+        # to bridge that gap and the concat fails. Use ``"permissive"`` to
+        # match what ``pyiceberg/io/pyarrow.py:to_table()`` already does
+        # for the same reason ("different batches can use different
+        # schema's (due to large_ types)").
+        new_content = pa.concat_tables([kept_rows, df], promote_options="permissive")
 
         # Step 4: Atomic single-snapshot commit.
         # Delete old files, append rewritten content.

--- a/tests/table/test_merge.py
+++ b/tests/table/test_merge.py
@@ -696,6 +696,166 @@ def test_merge_schema_preserved_after_anti_join(catalog: Catalog) -> None:
     assert result.column("score").to_pylist() == [150, 250]
 
 
+# ==================== ARROW TYPE-WIDTH DRIFT (string vs large_string) ====================
+
+
+def test_merge_handles_large_string_kept_rows_with_string_source(catalog: Catalog) -> None:
+    """Regression: kept_rows from ArrowScan can come back as ``large_string``
+    while a pandas->arrow source df typically produces ``string``.
+
+    The two encodings are semantically the same Iceberg text type but are
+    physically distinct PyArrow types. ``pa.concat_tables(..., promote_options="default")``
+    refuses to bridge them and merge() blows up with::
+
+        ArrowTypeError: Unable to merge: Field <name> has incompatible types:
+                       string vs large_string
+
+    This is the exact failure observed against real Iceberg parquet tables
+    (where ArrowScan returns ``large_*``) when consolidating multiple feeds
+    into one table via composite merge keys.
+
+    The fix in ``Transaction.merge()`` is to use ``promote_options="permissive"``
+    (matching what ``pyiceberg/io/pyarrow.py`` already does for the same
+    reason). This test pins that behavior.
+    """
+    ident = "default.merge_large_string_drift"
+    _drop(catalog, ident)
+    tbl = catalog.create_table(ident, schema=SCHEMA)
+
+    # Write the initial rows with ``large_string`` to simulate what
+    # ``ArrowScan.to_table()`` returns from a real Iceberg parquet read.
+    large_string_arrow = pa.schema(
+        [
+            pa.field("user_id", pa.int32(), nullable=False),
+            pa.field("name", pa.large_string(), nullable=False),
+            pa.field("score", pa.int32(), nullable=False),
+        ]
+    )
+    tbl.append(
+        pa.Table.from_pylist(
+            [
+                {"user_id": 1, "name": "Alice", "score": 100},
+                {"user_id": 2, "name": "Bob", "score": 200},
+            ],
+            schema=large_string_arrow,
+        )
+    )
+
+    # New batch using plain ``string`` (the pandas->arrow default for
+    # ``pd.StringDtype()`` columns).
+    assert ARROW.field("name").type == pa.string()
+    tbl.merge(
+        pa.Table.from_pylist(
+            [
+                {"user_id": 1, "name": "Alice", "score": 150},
+                {"user_id": 3, "name": "Charlie", "score": 300},
+            ],
+            schema=ARROW,
+        ),
+        join_cols=["user_id"],
+    )
+
+    result = tbl.scan().to_arrow().sort_by("user_id")
+    assert result.num_rows == 3
+    assert result.column("score").to_pylist() == [150, 200, 300]
+    assert result.column("name").to_pylist() == ["Alice", "Bob", "Charlie"]
+
+
+def test_merge_handles_string_kept_rows_with_large_string_source(catalog: Catalog) -> None:
+    """Mirror of the previous test - target is ``string``, source is
+    ``large_string``. Both directions must be tolerated since the
+    drift can flip either way depending on PyArrow version, file
+    metadata, and the ``PYARROW_USE_LARGE_TYPES_ON_READ`` setting.
+    """
+    ident = "default.merge_large_string_reverse"
+    _drop(catalog, ident)
+    tbl = catalog.create_table(ident, schema=SCHEMA)
+
+    tbl.append(
+        pa.Table.from_pylist(
+            [
+                {"user_id": 1, "name": "Alice", "score": 100},
+                {"user_id": 2, "name": "Bob", "score": 200},
+            ],
+            schema=ARROW,  # plain string
+        )
+    )
+
+    large_string_arrow = pa.schema(
+        [
+            pa.field("user_id", pa.int32(), nullable=False),
+            pa.field("name", pa.large_string(), nullable=False),
+            pa.field("score", pa.int32(), nullable=False),
+        ]
+    )
+    tbl.merge(
+        pa.Table.from_pylist(
+            [
+                {"user_id": 1, "name": "Alice", "score": 150},
+            ],
+            schema=large_string_arrow,
+        ),
+        join_cols=["user_id"],
+    )
+
+    result = tbl.scan().to_arrow().sort_by("user_id")
+    assert result.num_rows == 2
+    assert result.column("score").to_pylist() == [150, 200]
+
+
+def test_merge_handles_large_binary_kept_rows_with_binary_source(catalog: Catalog) -> None:
+    """Same drift family for binary columns: PyIceberg's ``ArrowScan`` can
+    return ``large_binary`` while user-provided sources typically have
+    ``binary``. ``"permissive"`` promote bridges these too.
+    """
+    from pyiceberg.types import BinaryType
+
+    binary_schema = Schema(
+        NestedField(1, "user_id", IntegerType(), required=True),
+        NestedField(2, "payload", BinaryType(), required=True),
+    )
+    ident = "default.merge_large_binary_drift"
+    _drop(catalog, ident)
+    tbl = catalog.create_table(ident, schema=binary_schema)
+
+    large_binary_arrow = pa.schema(
+        [
+            pa.field("user_id", pa.int32(), nullable=False),
+            pa.field("payload", pa.large_binary(), nullable=False),
+        ]
+    )
+    tbl.append(
+        pa.Table.from_pylist(
+            [
+                {"user_id": 1, "payload": b"alpha"},
+                {"user_id": 2, "payload": b"bravo"},
+            ],
+            schema=large_binary_arrow,
+        )
+    )
+
+    binary_arrow = pa.schema(
+        [
+            pa.field("user_id", pa.int32(), nullable=False),
+            pa.field("payload", pa.binary(), nullable=False),
+        ]
+    )
+    tbl.merge(
+        pa.Table.from_pylist(
+            [
+                {"user_id": 1, "payload": b"alpha-updated"},
+                {"user_id": 3, "payload": b"charlie"},
+            ],
+            schema=binary_arrow,
+        ),
+        join_cols=["user_id"],
+    )
+
+    result = tbl.scan().to_arrow().sort_by("user_id")
+    assert result.num_rows == 3
+    assert result.column("payload").to_pylist() == [b"alpha-updated", b"bravo", b"charlie"]
+
+
 # ==================== MERGE RESULT ====================
 
 


### PR DESCRIPTION
## Summary

`Transaction.merge()` (added in #7) hits an `ArrowTypeError` whenever the kept-after-anti-join rows from `ArrowScan.to_table()` come back with different physical PyArrow string/binary widths than the user-supplied source df. Default-mode promote in `pa.concat_tables` refuses to bridge `utf8 <-> large_utf8` and `binary <-> large_binary`, so any merge that mixes the two encodings blows up:

```
pyarrow.lib.ArrowTypeError: Unable to merge: Field <name> has incompatible types: string vs large_string
```

This happens on real Iceberg parquet round-trips (read returns `large_*`) the moment a user passes in a pandas-derived df (`numpy_nullable` -> `string` / `binary`).

## Fix

One-line change at `pyiceberg/table/__init__.py:999`:

```diff
-        new_content = pa.concat_tables([kept_rows, df], promote_options="default")
+        new_content = pa.concat_tables([kept_rows, df], promote_options="permissive")
```

This matches what `pyiceberg/io/pyarrow.py:to_table()` already does (with a comment specifically calling out the same `large_` type drift).

## Tests

Three new regression tests under `# ==================== ARROW TYPE-WIDTH DRIFT ====================` in `tests/table/test_merge.py`:

- `test_merge_handles_large_string_kept_rows_with_string_source` - target stored as `large_string`, source is `string` (the production failure mode)
- `test_merge_handles_string_kept_rows_with_large_string_source` - reverse direction (PyArrow version / metadata can flip which side is "large")
- `test_merge_handles_large_binary_kept_rows_with_binary_source` - same drift for binary columns

All three FAIL on the prior `"default"` code and PASS with `"permissive"`. Verified by reverting the production change locally and re-running the suite.

Full `tests/table/test_merge.py` suite: **29 passed** (26 existing + 3 new).

## Why the existing tests didn't catch this

All 26 existing merge tests share a single module-level `ARROW = pa.schema([..., pa.field("name", pa.string(), ...)])` constant and use it for both the initial `tbl.append(...)` and every `tbl.merge(...)` source. With the `InMemoryCatalog` round-trip, both sides therefore stay on `pa.string()`, never on `pa.large_string()`. The cross-encoding scenario that triggers the failure was never exercised. The new tests deliberately mismatch the kept-rows encoding against the source encoding to cover the gap.