### PR TITLE
Delete data files written for a rejected commit

### DIFF
--- a/pyiceberg/table/__init__.py
+++ b/pyiceberg/table/__init__.py
@@ -31,6 +31,7 @@ from typing import (
     Callable,
     Dict,
     Iterable,
+    Iterator,
     List,
     Optional,
     Set,
@@ -278,6 +279,7 @@ class Transaction:
     _updates: Tuple[TableUpdate, ...]
     _requirements: Tuple[TableRequirement, ...]
     _snapshot_operations: Tuple[UpdateTableMetadata[Any], ...]
+    _written_data_file_locations: List[str]
 
     def __init__(self, table: Table, autocommit: bool = False):
         """Open a transaction to stage and commit changes to a table.
@@ -291,6 +293,7 @@ class Transaction:
         self._updates = ()
         self._requirements = ()
         self._snapshot_operations = ()
+        self._written_data_file_locations = []
 
     @property
     def table_metadata(self) -> TableMetadata:
@@ -306,6 +309,38 @@ class Transaction:
         """Close and commit the transaction if no exceptions have been raised."""
         if exctype is None and excinst is None and exctb is None:
             self.commit_transaction()
+        else:
+            self._discard_written_data_files()
+
+    def _track_written_data_files(self, data_files: Iterable[DataFile]) -> Iterator[DataFile]:
+        """Record data files written by this transaction, so an abandoned transaction can remove them.
+
+        Only files written *here* are recorded. Files handed to the transaction by a caller — through
+        `add_files`, or by appending a `DataFile` to a snapshot producer directly — belong to that
+        caller, which may well intend to reuse them across commit attempts.
+        """
+        for data_file in data_files:
+            self._written_data_file_locations.append(data_file.file_path)
+            yield data_file
+
+    def _discard_written_data_files(self) -> None:
+        """Delete the data files this transaction wrote but did not commit.
+
+        Without this, every abandoned attempt leaves its data files behind. They are referenced by no
+        snapshot, so expiring snapshots never reclaims them, and only a `delete-orphan-files`
+        maintenance run — which waits for files to age, since a file being written right now is
+        indistinguishable from a stale one — eventually will. A copy-on-write delete makes that
+        expensive: each attempt rewrites every file its predicate partly matched.
+
+        Only safe when the commit certainly did not land. `CommitStateUnknownException` means the
+        outcome is unknown and the files may be live table data, so those are left to age out.
+        """
+        for location in self._written_data_file_locations:
+            try:
+                self._table.io.delete(location)
+            except Exception:
+                logger.warning(f"Failed to delete uncommitted data file {location}", exc_info=True)
+        self._written_data_file_locations = []
 
     def _apply(self, updates: Tuple[TableUpdate, ...], requirements: Tuple[TableRequirement, ...] = ()) -> Transaction:
         """Check if the requirements are met, and applies the updates to the metadata."""
@@ -515,8 +550,10 @@ class Transaction:
 
         append_snapshot_commit_uuid = uuid.uuid4()
         data_files = list(
-            _dataframe_to_data_files(
-                table_metadata=self.table_metadata, write_uuid=append_snapshot_commit_uuid, df=df, io=self._table.io
+            self._track_written_data_files(
+                _dataframe_to_data_files(
+                    table_metadata=self.table_metadata, write_uuid=append_snapshot_commit_uuid, df=df, io=self._table.io
+                )
             )
         )
         with self._append_snapshot_producer(snapshot_properties, branch=branch) as append_files:
@@ -573,8 +610,10 @@ class Transaction:
 
         append_snapshot_commit_uuid = uuid.uuid4()
         data_files: List[DataFile] = list(
-            _dataframe_to_data_files(
-                table_metadata=self._table.metadata, write_uuid=append_snapshot_commit_uuid, df=df, io=self._table.io
+            self._track_written_data_files(
+                _dataframe_to_data_files(
+                    table_metadata=self._table.metadata, write_uuid=append_snapshot_commit_uuid, df=df, io=self._table.io
+                )
             )
         )
 
@@ -642,8 +681,10 @@ class Transaction:
         with self._append_snapshot_producer(snapshot_properties, branch=branch) as append_files:
             # skip writing data files if the dataframe is empty
             if df.shape[0] > 0:
-                data_files = _dataframe_to_data_files(
-                    table_metadata=self.table_metadata, write_uuid=append_files.commit_uuid, df=df, io=self._table.io
+                data_files = self._track_written_data_files(
+                    _dataframe_to_data_files(
+                        table_metadata=self.table_metadata, write_uuid=append_files.commit_uuid, df=df, io=self._table.io
+                    )
                 )
                 for data_file in data_files:
                     append_files.append_data_file(data_file)
@@ -725,12 +766,14 @@ class Transaction:
                         (
                             original_file.file,
                             list(
-                                _dataframe_to_data_files(
-                                    io=self._table.io,
-                                    df=filtered_df,
-                                    table_metadata=self.table_metadata,
-                                    write_uuid=commit_uuid,
-                                    counter=counter,
+                                self._track_written_data_files(
+                                    _dataframe_to_data_files(
+                                        io=self._table.io,
+                                        df=filtered_df,
+                                        table_metadata=self.table_metadata,
+                                        write_uuid=commit_uuid,
+                                        counter=counter,
+                                    )
                                 )
                             ),
                         )
@@ -1029,11 +1072,13 @@ class Transaction:
         with self.update_snapshot(snapshot_properties=snapshot_properties, branch=branch).overwrite() as overwrite_op:
             for task in tasks:
                 overwrite_op.delete_data_file(task.file)
-            for data_file in _dataframe_to_data_files(
-                table_metadata=self.table_metadata,
-                df=new_content,
-                io=self._table.io,
-                write_uuid=overwrite_op.commit_uuid,
+            for data_file in self._track_written_data_files(
+                _dataframe_to_data_files(
+                    table_metadata=self.table_metadata,
+                    df=new_content,
+                    io=self._table.io,
+                    write_uuid=overwrite_op.commit_uuid,
+                )
             ):
                 overwrite_op.append_data_file(data_file)
 
@@ -1161,7 +1206,18 @@ class Transaction:
 
             return self._table
 
-        return _commit_transaction()
+        try:
+            table = _commit_transaction()
+        except CommitFailedException:
+            # The catalog rejected the commit, so nothing references the data files written for it.
+            # Any other failure — `CommitStateUnknownException` above all — may have committed, and
+            # those files are left for orphan-file cleanup to age out rather than risk deleting live data.
+            self._discard_written_data_files()
+            raise
+
+        # Committed: the files are table data now, and must outlive this transaction.
+        self._written_data_file_locations = []
+        return table
 
 
 class CreateTableTransaction(Transaction):

--- a/tests/table/test_commit_cleanup.py
+++ b/tests/table/test_commit_cleanup.py
@@ -1,0 +1,131 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+from pathlib import PosixPath
+from typing import Any, List, Set
+
+import pyarrow as pa
+import pytest
+
+from pyiceberg.exceptions import CommitFailedException, CommitStateUnknownException
+from pyiceberg.expressions import EqualTo
+from pyiceberg.io.pyarrow import _dataframe_to_data_files
+from pyiceberg.schema import Schema
+from pyiceberg.table import Table, Transaction
+from pyiceberg.table.metadata import COMMIT_NUM_RETRIES
+from pyiceberg.types import IntegerType, NestedField, StringType
+from tests.catalog.test_base import InMemoryCatalog
+
+SCHEMA = Schema(
+    NestedField(1, "id", IntegerType(), required=True),
+    NestedField(2, "name", StringType(), required=True),
+)
+
+ARROW_SCHEMA = pa.schema([pa.field("id", pa.int32(), nullable=False), pa.field("name", pa.string(), nullable=False)])
+
+
+@pytest.fixture
+def warehouse(tmp_path: PosixPath) -> PosixPath:
+    return tmp_path
+
+
+@pytest.fixture
+def table(warehouse: PosixPath) -> Table:
+    catalog = InMemoryCatalog("test.in_memory.catalog", warehouse=warehouse.absolute().as_posix())
+    catalog.create_namespace("default")
+    # A single attempt per commit, so a test asserting on one failed attempt is not asserting on five.
+    return catalog.create_table("default.cleanup", schema=SCHEMA, properties={COMMIT_NUM_RETRIES: "0"})
+
+
+def _rows(*ids: int) -> pa.Table:
+    return pa.table({"id": list(ids), "name": [f"row-{i}" for i in ids]}, schema=ARROW_SCHEMA)
+
+
+def _parquet_files(warehouse: PosixPath) -> Set[str]:
+    return {path.name for path in warehouse.rglob("*.parquet")}
+
+
+def _fail_commit_with(monkeypatch: pytest.MonkeyPatch, error: Exception) -> None:
+    def _do_commit(self: Table, **kwargs: Any) -> None:
+        raise error
+
+    monkeypatch.setattr(Table, "_do_commit", _do_commit)
+
+
+def test_rejected_append_deletes_the_data_file_it_wrote(
+    table: Table, warehouse: PosixPath, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    _fail_commit_with(monkeypatch, CommitFailedException("rejected"))
+
+    with pytest.raises(CommitFailedException):
+        table.append(_rows(1, 2))
+
+    assert _parquet_files(warehouse) == set()
+
+
+def test_rejected_copy_on_write_delete_deletes_the_rewritten_file(
+    table: Table, warehouse: PosixPath, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    table.append(_rows(1, 2))
+    committed = _parquet_files(warehouse)
+    _fail_commit_with(monkeypatch, CommitFailedException("rejected"))
+
+    with pytest.raises(CommitFailedException):
+        table.delete(EqualTo("id", 1))
+
+    assert _parquet_files(warehouse) == committed, (
+        "the rewritten survivors of a rejected delete are referenced by no snapshot and must not be left behind"
+    )
+
+
+def test_unknown_commit_state_keeps_the_data_file(table: Table, warehouse: PosixPath, monkeypatch: pytest.MonkeyPatch) -> None:
+    _fail_commit_with(monkeypatch, CommitStateUnknownException("no idea"))
+
+    with pytest.raises(CommitStateUnknownException):
+        table.append(_rows(1, 2))
+
+    assert _parquet_files(warehouse), (
+        "the commit may have landed, so the file may be live table data — leave it for orphan cleanup to age out"
+    )
+
+
+def test_rejected_commit_keeps_data_files_the_caller_supplied(
+    table: Table, warehouse: PosixPath, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Writers that write once and re-append across commit attempts own their files; the transaction
+    must not delete them out from under the next attempt.
+    """
+    data_files: List[Any] = list(_dataframe_to_data_files(table_metadata=table.metadata, df=_rows(1, 2), io=table.io))
+    supplied = _parquet_files(warehouse)
+    _fail_commit_with(monkeypatch, CommitFailedException("rejected"))
+
+    transaction = Transaction(table, autocommit=False)
+    with transaction.update_snapshot().fast_append() as append_files:
+        for data_file in data_files:
+            append_files.append_data_file(data_file)
+    with pytest.raises(CommitFailedException):
+        transaction.commit_transaction()
+
+    assert _parquet_files(warehouse) == supplied
+
+
+def test_abandoned_transaction_deletes_the_data_file_it_wrote(table: Table, warehouse: PosixPath) -> None:
+    with pytest.raises(RuntimeError):
+        with table.transaction() as transaction:
+            transaction.append(_rows(1, 2))
+            raise RuntimeError("caller gave up")
+
+    assert _parquet_files(warehouse) == set()


### PR DESCRIPTION
A transaction writes its data files to storage before it attempts the commit. When the catalog rejects that commit, nothing ever references those files: expiring snapshots cannot reclaim them, since no snapshot ever listed them, so they survive until a delete-orphan-files run, which deliberately waits for files to age before removing any. A copy-on-write delete makes that costly. Each attempt rewrites the surviving rows of every file its predicate only partly matched, so a writer retrying a contended commit strands a full copy of that data per attempt.

Track the data files a transaction writes itself, and delete them once the commit is definitively rejected. Only CommitFailedException qualifies: CommitStateUnknownException means the outcome is unknown and the files may be live table data, so those are left for orphan-file cleanup to age out. A `with` block abandoned by an exception cleans up for the same reason, having committed nothing.

The Java implementation draws the same line. SnapshotProducer.commit() rethrows CommitStateUnknownException without cleaning up, and calls cleanAll() for the failures marked CleanableFailure, of which CommitFailedException is one. It treats more failures as cleanable than this does — ValidationException, BadRequestException, ForbiddenException, NotAuthorizedException, ServiceUnavailableException and the NoSuchTable family also mean the request was never applied — so widening the set here is a reasonable follow-up. Starting with the one unambiguous case keeps the blast radius of a wrong call small.

Files handed to the transaction by a caller, through add_files or by appending a DataFile to a snapshot producer directly, are left alone. A caller may write its files once and re-append them across commit attempts rather than pay for the write again, and deleting them would break the attempt that follows.